### PR TITLE
For out of tree builds, the include directories need to reference the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+example/ot_parser
+example/sample_parser
+unittest/regression

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2")
 
 # add the binary tree to the search path for include files
 include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(parser-verilog)
 
 


### PR DESCRIPTION
… newly generated .hh files in the 'build' (or whatever out of tree build) directory. CMakeLists.txt was updated to reflect this: include_directories(). Also, I added a .gitignore to prevent executables (i.e. example/ot_parser, example/sample_parser, unittest/regression) from being sucked into a commit.