### PR TITLE
Updates regarding FLEX and experimental filesystem

### DIFF
--- a/example/ot_parser.cpp
+++ b/example/ot_parser.cpp
@@ -94,7 +94,7 @@ int main(const int argc, const char **argv){
     return EXIT_FAILURE;
   }
   
-  if(std::experimental::filesystem::exists(argv[1])) { 
+  if(std::filesystem::exists(argv[1])) { 
     OpenTimerParser parser;
     parser.read(argv[1]);
   }

--- a/example/sample_parser.cpp
+++ b/example/sample_parser.cpp
@@ -43,7 +43,7 @@ int main(const int argc, const char **argv){
     return EXIT_FAILURE;
   }
   
-  if(std::experimental::filesystem::exists(argv[1])) { 
+  if(std::filesystem::exists(argv[1])) { 
     SampleParser parser;
     parser.read(argv[1]);
   }

--- a/parser-verilog/verilog_driver.hpp
+++ b/parser-verilog/verilog_driver.hpp
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <variant>
 #include <unordered_map>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "verilog_scanner.hpp"
 #include "verilog_parser.tab.hh"
@@ -26,15 +26,15 @@ class ParserVerilogInterface {
     virtual void add_assignment(Assignment&&) = 0;
     virtual void add_instance(Instance&&) = 0;
 
-    void read(const std::experimental::filesystem::path&); 
+    void read(const std::filesystem::path&); 
 
   private:
     VerilogScanner* _scanner {nullptr};
     VerilogParser*  _parser {nullptr};
 };
 
-inline void ParserVerilogInterface::read(const std::experimental::filesystem::path& p){
-  if(! std::experimental::filesystem::exists(p)){
+inline void ParserVerilogInterface::read(const std::filesystem::path& p){
+  if(! std::filesystem::exists(p)){
     return ;
   }
 

--- a/parser-verilog/verilog_parser.yy
+++ b/parser-verilog/verilog_parser.yy
@@ -3,7 +3,7 @@
 %debug 
 %defines 
 %define api.namespace {verilog}
-%define parser_class_name {VerilogParser}
+%define api.parser.class {VerilogParser}
 
 %define parse.error verbose
 

--- a/unittest/regression.cpp
+++ b/unittest/regression.cpp
@@ -23,7 +23,7 @@ int main(const int argc, const char **argv){
             << std::setw(13) << "[Runtime]" << '\n';
   std::cout << std::string(45, '-') << '\n';
 
-  for(const auto&p : std::experimental::filesystem::directory_iterator("../benchmark/")){
+  for(const auto&p : std::filesystem::directory_iterator("../benchmark/")){
 
     std::cout << std::setw(10) << "Parsing " 
               << std::setw(20) << p.path().filename().string() ;


### PR DESCRIPTION
Remove deprecated directive warning for lexer.
Switch usage of `std::experimental::filesystem` to `std::filesystem` as it has been merged into the mainline ISO C++ standard.