### PR TITLE
Fix compilation under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(sample_parser
   ${FLEX_verilog_lexer_OUTPUTS}
   ${BISON_verilog_parser_OUTPUTS}
 )
+target_include_directories(sample_parser SYSTEM PRIVATE ${FLEX_INCLUDE_DIRS})
 
 # A drop-in replacement OpenTimer Verilog parser
 add_executable(ot_parser
@@ -52,6 +53,7 @@ add_executable(ot_parser
   ${FLEX_verilog_lexer_OUTPUTS}
   ${BISON_verilog_parser_OUTPUTS}
 )
+target_include_directories(ot_parser SYSTEM PRIVATE ${FLEX_INCLUDE_DIRS})
 
 
 
@@ -67,5 +69,6 @@ set(VP_UTEST_DIR ${PROJECT_SOURCE_DIR}/unittest)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${VP_UTEST_DIR})
 
 add_executable(regression unittest/regression.cpp ${FLEX_verilog_lexer_OUTPUTS} ${BISON_verilog_parser_OUTPUTS})
+target_include_directories(regression SYSTEM PRIVATE ${FLEX_INCLUDE_DIRS})
 add_test(regression ${VP_UTEST_DIR}/regression)
 

--- a/parser-verilog/verilog_data.hpp
+++ b/parser-verilog/verilog_data.hpp
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <iostream>
 #include <variant>
-#include <experimental/filesystem>
+#include <vector>
 
 
 namespace verilog {

--- a/parser-verilog/verilog_lexer.l
+++ b/parser-verilog/verilog_lexer.l
@@ -1,3 +1,8 @@
+/* Avoid redefinition warnings on MSVC */
+%top{
+#include <stdint.h>
+}
+
 %{
 /* C++ string header, for string ops below */
 #include <string>


### PR DESCRIPTION
PR removes `experimental/filesystem` header file as it is no longer required after #5. The header also causes the following error on MSVC:

```
fatal error C1189: #error:  The <experimental/filesystem> header providing std::experimental::filesystem is deprecated by Microsoft and will be REMOVED. It is superseded by the C++17 <filesystem> header providing std::filesystem. You can define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING to acknowledge that you have received this warning.
```

Also on Windows it's required to include Flex include directories to get access to `FlexLexer.h`.