### PR TITLE
generate compile_commands.json for IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2")
 
+# Help LSP-based IDEs (VSCode, Neovim, etc.)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # add the binary tree to the search path for include files
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build/compile_commands.json


### PR DESCRIPTION
This asks CMake to generate a `compile_commands.json` file so that your IDE (if it uses Language Server Protocol, like VSCode does) can properly syntax-check the files.